### PR TITLE
Fix installation issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 	},
 	"scripts": {
 		"build": "tsc",
-		"watch": "tsc --watch"
+		"watch": "tsc --watch",
+		"postinstall": "tsc"
 	},
 	"devDependencies": {
 		"@types/eventsource": "^1.1.2",


### PR DESCRIPTION
Fixes #10 (I think)

I'm not sure what exactly the `build` or `watch` scripts are doing, if anything; I can replace them completely if desired, but this seemed like a less invasive fix ([the docs](https://docs.npmjs.com/misc/scripts#description) for the `postinstall` script).

You can correct me if I'm wrong, but for the installation to work properly users will need TypeScript installed. Should I also add a change to the README? 

Thanks so much!