### PR TITLE
Build the project on postinstall

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,63 +1,28 @@
 {
-	"name": "hoon-language-server",
+	"name": "@urbit/hoon-language-server",
 	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@types/color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-		},
 		"@types/eventsource": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.5.tgz",
-			"integrity": "sha512-BA9q9uC2PAMkUS7DunHTxWZZaVpeNzDG8lkBxcKwzKJClfDQ4Z59/Csx7HSH/SIqFN2JWh0tAKAM6k/wRR0OZg==",
-			"dev": true
+			"integrity": "sha512-BA9q9uC2PAMkUS7DunHTxWZZaVpeNzDG8lkBxcKwzKJClfDQ4Z59/Csx7HSH/SIqFN2JWh0tAKAM6k/wRR0OZg=="
 		},
 		"@types/lodash": {
 			"version": "4.14.149",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
-			"dev": true
+			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
 		},
 		"@types/node": {
 			"version": "13.1.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.1.tgz",
-			"integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ==",
-			"dev": true
-		},
-		"@types/pino": {
-			"version": "5.15.1",
-			"resolved": "https://registry.npmjs.org/@types/pino/-/pino-5.15.1.tgz",
-			"integrity": "sha512-skJZ2VBHUva/dF4b2/3zOYVOZLyeaYT7wtPyf8+aoh0VuqfW8JO7PK9oJY8yRZVkN4K7RDdA5UFuH0QbbENZaw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*",
-				"@types/pino-std-serializers": "*",
-				"@types/sonic-boom": "*"
-			}
-		},
-		"@types/pino-std-serializers": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.0.tgz",
-			"integrity": "sha512-eAdu+NW1IkCdmp85SnhyKha+OOREQMT9lXaoICQxa7bhSauRiLzu3WSNt9Mf2piuJvWeXF/G0hGWHr63xNpIRA==",
-			"dev": true
-		},
-		"@types/sonic-boom": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@types/sonic-boom/-/sonic-boom-0.7.0.tgz",
-			"integrity": "sha512-AfqR0fZMoUXUNwusgXKxcE9DPlHNDHQp6nKYUd4PSRpLobF5CCevSpyTEBcVZreqaWKCnGBr9KI1fHMTttoB7A==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
+			"integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ=="
 		},
 		"@types/yargs": {
 			"version": "15.0.0",
 			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.0.tgz",
 			"integrity": "sha512-TITCsNxRSDVmq3kPGuUdKZTPTfHeswsUGIjxSe8SB4EBKTPA0DO0y4yWI95kZ2hfqJAYxmu+gxzjOwdumB5S0g==",
-			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
 			}
@@ -65,36 +30,34 @@
 		"@types/yargs-parser": {
 			"version": "13.1.0",
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
-			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
-			"dev": true
+			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
 		},
 		"ansi-regex": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
 		},
 		"ansi-styles": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-			"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"requires": {
-				"@types/color-name": "^1.1.1",
 				"color-convert": "^2.0.1"
 			}
 		},
-		"camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+		"atomic-sleep": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
 		},
 		"cliui": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
 			"requires": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^6.2.0"
+				"wrap-ansi": "^7.0.0"
 			}
 		},
 		"color-convert": {
@@ -110,15 +73,34 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
-		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+		"duplexify": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+			"integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+			"requires": {
+				"end-of-stream": "^1.4.1",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1",
+				"stream-shift": "^1.0.0"
+			}
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
 		},
 		"eventsource": {
 			"version": "1.0.7",
@@ -129,33 +111,19 @@
 			}
 		},
 		"fast-redact": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
-			"integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
-		},
-		"fast-safe-stringify": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
-		},
-		"find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"requires": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			}
-		},
-		"flatstr": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
+			"integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A=="
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"is-fullwidth-code-point": {
 			"version": "3.0.0",
@@ -167,18 +135,10 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
-		"locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"requires": {
-				"p-locate": "^4.1.0"
-			}
-		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -193,6 +153,19 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"on-exit-leak-free": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+			"integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
 		"original": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
@@ -201,49 +174,41 @@
 				"url-parse": "^1.4.3"
 			}
 		},
-		"p-limit": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-			"requires": {
-				"p-try": "^2.0.0"
-			}
-		},
-		"p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"requires": {
-				"p-limit": "^2.2.0"
-			}
-		},
-		"p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-		},
-		"path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-		},
 		"pino": {
-			"version": "5.15.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-5.15.0.tgz",
-			"integrity": "sha512-7+FXMTA3H3sNP5+2miY2K9JKnAAW5GKuhHfNWsukFCsPprGQY3ctqpwbV74wAHW3Nl93cEEQ1G82MgOLM8P7TQ==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-7.8.0.tgz",
+			"integrity": "sha512-Ynw2HRVapiyj+ZGfUcpms+SRgDKFIy0ztaFUf3X6IHh+vsysMvn+tpV/Ej3gyutPp4n9tgH6ZkkCAelSvP5zmQ==",
 			"requires": {
-				"fast-redact": "^2.0.0",
-				"fast-safe-stringify": "^2.0.7",
-				"flatstr": "^1.0.12",
-				"pino-std-serializers": "^2.4.2",
-				"quick-format-unescaped": "^3.0.3",
-				"sonic-boom": "^0.7.5"
+				"fast-redact": "^3.0.0",
+				"on-exit-leak-free": "^0.2.0",
+				"pino-abstract-transport": "v0.5.0",
+				"pino-std-serializers": "^4.0.0",
+				"process-warning": "^1.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.1.0",
+				"safe-stable-stringify": "^2.1.0",
+				"sonic-boom": "^2.2.1",
+				"thread-stream": "^0.13.0"
+			}
+		},
+		"pino-abstract-transport": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+			"integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+			"requires": {
+				"duplexify": "^4.1.2",
+				"split2": "^4.0.0"
 			}
 		},
 		"pino-std-serializers": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
-			"integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ=="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+			"integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
+		},
+		"process-warning": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+			"integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
 		},
 		"prop-types": {
 			"version": "15.7.2",
@@ -261,9 +226,9 @@
 			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
 		},
 		"quick-format-unescaped": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-			"integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
 		},
 		"react": {
 			"version": "16.13.1",
@@ -280,57 +245,97 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
+		"readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
+		},
+		"real-require": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+			"integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
+		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-		},
-		"require-main-filename": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
 		},
 		"requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
-		"set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+		},
+		"safe-stable-stringify": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+			"integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
 		},
 		"sonic-boom": {
-			"version": "0.7.6",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.6.tgz",
-			"integrity": "sha512-k9E2QQ4zxuVRLDW+ZW6ISzJs3wlEorVdmM7ApDgor7wsGKSDG5YGHsGmgLY4XYh4DMlr/2ap2BWAE7yTFJtWnQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.6.0.tgz",
+			"integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
 			"requires": {
-				"flatstr": "^1.0.12"
+				"atomic-sleep": "^1.0.0"
 			}
 		},
+		"split2": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+			"integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
+		},
+		"stream-shift": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+		},
 		"string-width": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
+				"strip-ansi": "^6.0.1"
+			}
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"requires": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"requires": {
-				"ansi-regex": "^5.0.0"
+				"ansi-regex": "^5.0.1"
+			}
+		},
+		"thread-stream": {
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.13.2.tgz",
+			"integrity": "sha512-woZFt0cLFkPdhsa+IGpRo1jiSouaHxMIljzTgt30CMjBWoUYbbcHqnunW5Yv+BXko9H05MVIcxMipI3Jblallw==",
+			"requires": {
+				"real-require": "^0.1.0"
 			}
 		},
 		"typescript": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-			"dev": true
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
 		},
 		"urbit-airlock": {
 			"version": "0.0.2",
@@ -343,13 +348,18 @@
 			}
 		},
 		"url-parse": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-			"integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
 			"requires": {
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
 			}
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"vscode-jsonrpc": {
 			"version": "4.0.0",
@@ -384,52 +394,44 @@
 			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.8.tgz",
 			"integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ=="
 		},
-		"which-module": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
-		},
 		"wrap-ansi": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"requires": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0"
 			}
 		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
 		},
 		"yargs": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-			"integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+			"version": "17.3.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+			"integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
 			"requires": {
-				"cliui": "^6.0.0",
-				"decamelize": "^1.2.0",
-				"find-up": "^4.1.0",
-				"get-caller-file": "^2.0.1",
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
 				"require-directory": "^2.1.1",
-				"require-main-filename": "^2.0.0",
-				"set-blocking": "^2.0.0",
-				"string-width": "^4.2.0",
-				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
-				"yargs-parser": "^16.1.0"
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.0.0"
 			}
 		},
 		"yargs-parser": {
-			"version": "16.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-			"integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-			"requires": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			}
+			"version": "21.0.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+			"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,23 +15,21 @@
 		"hoon-language-server": "./bin/index.js"
 	},
 	"dependencies": {
-		"eventsource": "^1.0.7",
-		"lodash": "^4.17.15",
-		"pino": "^5.15.0",
-		"urbit-airlock": "0.0.2",
-		"vscode-languageserver": "^5.2.1",
-		"yargs": "^15.1.0"
-	},
-	"scripts": {
-		"build": "tsc",
-		"watch": "tsc --watch"
-	},
-	"devDependencies": {
 		"@types/eventsource": "^1.1.5",
 		"@types/lodash": "^4.14.149",
 		"@types/node": "^13.1.1",
-		"@types/pino": "^5.15.1",
 		"@types/yargs": "^15.0.0",
-		"typescript": "^3.8.3"
+		"eventsource": "^1.0.7",
+		"lodash": "^4.17.21",
+		"pino": "^7.8.0",
+		"typescript": "^3.8.3",
+		"urbit-airlock": "0.0.2",
+		"vscode-languageserver": "^5.2.1",
+		"yargs": "^17.3.1"
+	},
+	"scripts": {
+		"postinstall": "npm run build",
+		"build": "tsc",
+		"watch": "tsc --watch"
 	}
 }


### PR DESCRIPTION
Right now `npm i -g hoon-language-server` does not actually work due to a missing compilation step.

This change adds a `postinstall` script to perform the build on installation.  You can try it out now by running `npm i -g git+https://github.com/urbitme/hoon-language-server`

It was necessary to move the typescript devDependencies all to dependencies, and I also applied the updates from `npm audit fix`.

This fixes issue #10 and makes obsolete pull requests #11 #12 #14 #17 